### PR TITLE
Force marian-lite to use SSE4.1 only

### DIFF
--- a/dev.ters.LocalTranslate.yml
+++ b/dev.ters.LocalTranslate.yml
@@ -79,8 +79,7 @@ modules:
     config-opts:
       - "-DSTATIC=OFF"
       - "-DSHARED=ON"
-      - "-DCMAKE_C_FLAGS=-O3 -march=broadwell"
-      - "-DCMAKE_CXX_FLAGS=-O3 -march=broadwell"      
+      - "-DBUILD_ARCH=x86-64"
     sources:
       - type: archive
         url: https://github.com/kroketio/marian-lite/archive/refs/tags/0.2.9.tar.gz

--- a/dev.ters.LocalTranslate.yml
+++ b/dev.ters.LocalTranslate.yml
@@ -79,6 +79,8 @@ modules:
     config-opts:
       - "-DSTATIC=OFF"
       - "-DSHARED=ON"
+      - "-DCMAKE_C_FLAGS=-O3 -march=broadwell"
+      - "-DCMAKE_CXX_FLAGS=-O3 -march=broadwell"      
     sources:
       - type: archive
         url: https://github.com/kroketio/marian-lite/archive/refs/tags/0.2.9.tar.gz


### PR DESCRIPTION
Fix for https://github.com/terslang/LocalTranslate/issues/20